### PR TITLE
fix: avoid apt wrappers (like on Linux Mint)

### DIFF
--- a/internal/packages/apt.go
+++ b/internal/packages/apt.go
@@ -25,12 +25,15 @@ func NewAPTManager(logger *logrus.Logger) *APTManager {
 
 // detectPackageManager detects whether to use apt or apt-get
 func (m *APTManager) detectPackageManager() string {
-	// Prefer apt over apt-get for modern Debian-based systems
-	packageManager := "apt"
-	if _, err := exec.LookPath("apt"); err != nil {
-		packageManager = "apt-get"
-	}
-	return packageManager
+    if _, err := exec.LookPath("/usr/bin/apt"); err == nil {
+        return "/usr/bin/apt"
+    }
+    // Fallback to checking for "apt" in PATH
+    if _, err := exec.LookPath("apt"); err == nil {
+        return "apt"
+    }
+    // As a last resort, try "apt-get"
+    return "apt-get"
 }
 
 // GetPackages gets package information for APT-based systems


### PR DESCRIPTION
Hello :wave: 

This PR updates the APT package manager detection logic to avoid the Linux Mint wrapper script at /usr/local/bin/apt, which breaks the upgrade simulations. The new logic prefers /usr/bin/apt (the upstream binary), falls back to "apt" in PATH, and only uses "apt-get" as a last resort.

This ensures compatibility across all Debian-like distributions, including Mint, Ubuntu, and Debian, and prevents issues caused by wrapper scripts interfering with package management commands.

Why:
On Linux Mint, the default "apt" is a wrapper that breaks automation. Using the upstream binary directly ensures correct behavior for package updates and upgrades.

before:
```text
time="2025-12-20T08:34:11" level=debug msg="Getting upgradable packages..."
time="2025-12-20T08:34:11" level=warning msg="Failed to get upgrade simulation" error="exit status 1"
```

after:
```text
time="2025-12-20T10:12:17" level=debug msg="Getting upgradable packages..."
time="2025-12-20T10:12:18" level=debug msg="Parsing apt upgrade simulation output..."
time="2025-12-20T10:12:18" level=debug msg="Found upgradable packages" count=35
```


Thanks
