### PR TITLE
fix: resolve kernel version detection for Debian/Ubuntu meta-packages

### DIFF
--- a/internal/system/reboot.go
+++ b/internal/system/reboot.go
@@ -121,8 +121,8 @@ func (d *Detector) getLatestKernelFromBoot() string {
 		// Look for vmlinuz-* files
 		if strings.HasPrefix(name, "vmlinuz-") {
 			version := strings.TrimPrefix(name, "vmlinuz-")
-			// Skip generic/recovery kernels
-			if strings.Contains(version, "generic") || strings.Contains(version, "recovery") {
+			// Skip recovery kernels but keep generic kernels
+			if strings.Contains(version, "recovery") {
 				continue
 			}
 			kernels = append(kernels, version)
@@ -244,7 +244,9 @@ func (d *Detector) getLatestKernelFromDpkg() string {
 		return ""
 	}
 
-	var latestVersion string
+	var kernels []string
+	metaPackages := make(map[string]bool)
+
 	lines := strings.Split(string(output), "\n")
 	for _, line := range lines {
 		fields := strings.Fields(line)
@@ -254,19 +256,76 @@ func (d *Detector) getLatestKernelFromDpkg() string {
 
 		// Look for installed kernel image packages
 		if fields[0] == "ii" && strings.HasPrefix(fields[1], "linux-image-") {
-			// Extract version from package name
-			// Format: linux-image-VERSION or linux-image-X.Y.Z-N-generic
 			pkgName := fields[1]
 			version := strings.TrimPrefix(pkgName, "linux-image-")
 
-			// Skip meta packages
-			if version == "generic" || version == "lowlatency" {
-				continue
+			// Identify meta-packages (generic, virtual, lowlatency, etc.)
+			if version == "generic" || version == "virtual" || version == "lowlatency" ||
+				version == "server" || version == "cloud" || version == "kvm" {
+				metaPackages[pkgName] = true
+			} else {
+				// This is an actual kernel package with version
+				kernels = append(kernels, version)
 			}
-
-			latestVersion = version
 		}
 	}
 
-	return latestVersion
+	// If we found actual kernel versions, return the latest
+	if len(kernels) > 0 {
+		// Sort kernels by version and return the latest
+		sort.Slice(kernels, func(i, j int) bool {
+			return compareKernelVersions(kernels[i], kernels[j]) < 0
+		})
+		return kernels[len(kernels)-1]
+	}
+
+	// If we only found meta-packages, resolve dependencies to find actual kernels
+	for metaPkg := range metaPackages {
+		if actualVersion := d.resolveMetaPackage(metaPkg); actualVersion != "" {
+			return actualVersion
+		}
+	}
+
+	return ""
+}
+
+// resolveMetaPackage resolves a meta-package (like linux-image-virtual) to the actual kernel version
+func (d *Detector) resolveMetaPackage(metaPkg string) string {
+	// Use dpkg-query to get the dependencies
+	cmd := exec.Command("dpkg-query", "-W", "-f=${Depends}", metaPkg)
+	output, err := cmd.Output()
+	if err != nil {
+		d.logger.WithError(err).Debug("Failed to query package dependencies")
+		return ""
+	}
+
+	depends := string(output)
+
+	// Parse dependencies to find linux-image-X.Y.Z-N-generic
+	// Dependencies format: "package1 (>= version), package2, ..."
+	parts := strings.Split(depends, ",")
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+
+		// Remove version constraints like (>= 6.8.0.31.31)
+		if idx := strings.Index(part, " ("); idx != -1 {
+			part = part[:idx]
+		}
+
+		// Check if this is a linux-image package with actual version
+		if strings.HasPrefix(part, "linux-image-") {
+			version := strings.TrimPrefix(part, "linux-image-")
+
+			// Skip if this is another meta-package
+			if version == "generic" || version == "virtual" || version == "lowlatency" ||
+				version == "server" || version == "cloud" || version == "kvm" {
+				continue
+			}
+
+			// This should be an actual kernel version
+			return version
+		}
+	}
+
+	return ""
 }


### PR DESCRIPTION
# Fix: Resolve kernel version detection for Debian/Ubuntu meta-packages

## Problem
On Debian-based virtualized systems, the agent incorrectly reported kernel version mismatches, causing false-positive reboot requirements. The issue occurred because meta-packages like `linux-image-virtual`, `linux-image-generic`, etc., were not being resolved to their actual kernel versions.

## Changes

### 1. Updated `getLatestKernelFromBoot()`
- Removed filter that excluded "generic" kernels
- Now only skips "recovery" kernels
- Properly detects kernels like `6.8.0-90-generic` from `/boot` directory

### 2. Rewrote `getLatestKernelFromDpkg()`
- Multi-stage detection: first scans for actual kernel packages with full version numbers
- Identifies meta-packages (virtual, generic, lowlatency, server, cloud, kvm)
- Falls back to dependency resolution if only meta-packages are found
- Properly sorts all found kernels to return the latest version

### 3. Added `resolveMetaPackage()`
- New function to resolve meta-packages to actual kernel versions
- Uses `dpkg-query` to read package dependencies
- Parses dependency strings to find correct kernel packages
- Filters out nested meta-packages

## Testing

### Tested on Raspberry Pi 5 (Debian 13)
```
patchmon-agent diagnostics 2>&1 | grep -A 5 -i "reboot"
  time="2025-12-24T03:25:31" level=info msg="Reboot status check completed" installed_kernel=6.12.47+rpt-rpi-v8 needs_reboot=false reason= running_kernel=6.12.47+rpt-rpi-v8
```
Correctly detects matching kernels with custom suffixes

### Tested on Proxmox VE
```
patchmon-agent diagnostics 2>&1 | grep -A 5 -i "reboot"
  time="2025-12-24T03:25:15" level=info msg="Reboot status check completed" installed_kernel=6.17.4-1-pve needs_reboot=true reason="Reboot flag file exists (/var/run/reboot-required) | Running kernel: 6.17.2-2-pve, Installed kernel: 6.17.4-1-pve" running_kernel=6.17.2-2-pve
```
Correctly detects actual kernel updates requiring reboot

### Tested on Ubuntu 24.04 (Virtualized)
**Before fix:**
```
patchmon-agent diagnostics 2>&1 | grep -A 5 -i "reboot"
  time="2025-12-24T03:25:20" level=info msg="Reboot status check completed" installed_kernel=virtual needs_reboot=true reason="Kernel version mismatch | Running kernel: 6.8.0-90-generic, Installed kernel: virtual" running_kernel=6.8.0-90-generic
```
False positive - meta-package not resolved

**After fix:**
```
patchmon-agent diagnostics 2>&1 | grep -A 5 -i "reboot"
  time="2025-12-24T03:19:55" level=info msg="Reboot status check completed" installed_kernel=6.8.0-90-generic needs_reboot=false reason= running_kernel=6.8.0-90-generic
```
Correctly resolves `linux-image-virtual` to `6.8.0-90-generic`

## Impact
- Eliminates false-positive reboot requirements on virtualized Debian/Ubuntu systems
- Should maintain backward compatibility with RHEL/Fedora systems
- Should work across all Linux distributions with proper fallback mechanisms
- No breaking changes to existing functionality

# Notes (important)
 **Testing required before merge**
This fix has been tested on Debian-based systems (Debian 13, Ubuntu 24.04, Raspberry Pi OS). I only had VMs/physical devices with these distributions in my home lab. Before merging, it should be tested on all OS distributions (all those officially supported by the project).
