### PR TITLE
feat: Add Windows host support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ build-all:
 	@GOOS=linux GOARCH=386 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-linux-386 ./cmd/patchmon-agent
 	@GOOS=linux GOARCH=arm64 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-linux-arm64 ./cmd/patchmon-agent
 	@GOOS=linux GOARCH=arm CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-linux-arm ./cmd/patchmon-agent
+	@GOOS=windows GOARCH=amd64 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-windows-amd64.exe ./cmd/patchmon-agent
+	@GOOS=windows GOARCH=386 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-windows-386.exe ./cmd/patchmon-agent
 
 # Install dependencies
 .PHONY: deps

--- a/cmd/patchmon-agent/commands/root.go
+++ b/cmd/patchmon-agent/commands/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"patchmon-agent/internal/config"
 	"patchmon-agent/internal/constants"
@@ -125,8 +126,17 @@ func updateLogLevel(cmd *cobra.Command) {
 	}
 }
 
-// checkRoot ensures the command is run as root
+// checkRoot ensures the command is run as root/admin
 func checkRoot() error {
+	if runtime.GOOS == "windows" {
+		// Windows - check if running as administrator
+		// For Windows, we'll skip the check here and let commands fail gracefully
+		// Checking admin status in pure Go requires cgo or external commands
+		// The Windows package manager (PowerShell) will fail if not admin
+		return nil
+	}
+	
+	// Linux/Unix - check if running as root
 	if os.Geteuid() != 0 {
 		return fmt.Errorf("this command requires root privileges, please run with sudo or as root user")
 	}

--- a/cmd/patchmon-agent/commands/service_unix.go
+++ b/cmd/patchmon-agent/commands/service_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+// +build !windows
+
+package commands
+
+// isWindowsService always returns false on non-Windows platforms
+func isWindowsService() bool {
+	return false
+}
+
+// runAsService on non-Windows just runs the service loop directly
+func runAsService() error {
+	// On Unix, we don't need Windows Service wrapper
+	// Just run the service loop with no stop channel (runs forever)
+	return runServiceLoop(nil)
+}
+

--- a/cmd/patchmon-agent/commands/service_windows.go
+++ b/cmd/patchmon-agent/commands/service_windows.go
@@ -1,0 +1,147 @@
+//go:build windows
+// +build windows
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/eventlog"
+)
+
+// signalNotify wraps signal.Notify for Windows
+var signalNotify = signal.Notify
+
+const serviceName = "PatchMonAgent"
+
+// patchmonService implements svc.Handler interface for Windows Service
+type patchmonService struct {
+	stopCh chan struct{}
+}
+
+// Execute is called by Windows Service Control Manager
+func (s *patchmonService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (ssec bool, errno uint32) {
+	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
+
+	// Notify SCM that we're starting
+	changes <- svc.Status{State: svc.StartPending}
+
+	// Start the actual service logic in a goroutine
+	s.stopCh = make(chan struct{})
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- runServiceLoop(s.stopCh)
+	}()
+
+	// Notify SCM that we're running
+	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
+
+	// Wait for stop signal or error
+	for {
+		select {
+		case err := <-errCh:
+			if err != nil {
+				elog, _ := eventlog.Open(serviceName)
+				if elog != nil {
+					elog.Error(1, fmt.Sprintf("Service error: %v", err))
+					elog.Close()
+				}
+				return false, 1
+			}
+			return false, 0
+		case c := <-r:
+			switch c.Cmd {
+			case svc.Interrogate:
+				changes <- c.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				changes <- svc.Status{State: svc.StopPending}
+				close(s.stopCh)
+				// Wait briefly for clean shutdown
+				select {
+				case <-errCh:
+				case <-time.After(10 * time.Second):
+				}
+				return false, 0
+			default:
+				elog, _ := eventlog.Open(serviceName)
+				if elog != nil {
+					elog.Error(1, fmt.Sprintf("Unexpected control request #%d", c))
+					elog.Close()
+				}
+			}
+		}
+	}
+}
+
+// isWindowsService checks if we're running as a Windows Service
+func isWindowsService() bool {
+	isService, err := svc.IsWindowsService()
+	if err != nil {
+		// If we can't determine, assume interactive (not a service)
+		return false
+	}
+	return isService
+}
+
+// runWindowsService starts the Windows Service
+func runWindowsService() error {
+	elog, err := eventlog.Open(serviceName)
+	if err != nil {
+		// If we can't open event log, try to continue anyway
+		elog = nil
+	}
+	defer func() {
+		if elog != nil {
+			elog.Close()
+		}
+	}()
+
+	if elog != nil {
+		elog.Info(1, fmt.Sprintf("Starting %s service", serviceName))
+	}
+
+	err = svc.Run(serviceName, &patchmonService{})
+	if err != nil {
+		if elog != nil {
+			elog.Error(1, fmt.Sprintf("Service failed: %v", err))
+		}
+		return fmt.Errorf("service failed: %w", err)
+	}
+
+	if elog != nil {
+		elog.Info(1, fmt.Sprintf("%s service stopped", serviceName))
+	}
+	return nil
+}
+
+// runAsService determines if running as service or interactive and runs appropriately
+func runAsService() error {
+	isService := isWindowsService()
+
+	if isService {
+		return runWindowsService()
+	}
+
+	// Running interactively - run directly with signal handling
+	logger.Info("Running in interactive mode (not as Windows Service)")
+	logger.Info("Press Ctrl+C to stop")
+
+	stopCh := make(chan struct{})
+
+	// Handle Ctrl+C gracefully
+	go func() {
+		sigCh := make(chan os.Signal, 1)
+		signalNotify(sigCh, os.Interrupt)
+		<-sigCh
+		logger.Info("Interrupt received, shutting down...")
+		close(stopCh)
+	}()
+
+	return runServiceLoop(stopCh)
+}
+

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -20,6 +20,7 @@ const (
 	OSTypePop        = "pop"
 	OSTypeMint       = "linuxmint"
 	OSTypeElementary = "elementary"
+	OSTypeWindows    = "windows"
 )
 
 // Architecture constants
@@ -51,6 +52,8 @@ const (
 	RepoTypeDebSrc = "deb-src"
 	RepoTypeRPM    = "rpm"
 	RepoTypeAPK    = "apk"
+	RepoTypeWU     = "windows-update" // Windows Update
+	RepoTypeWSUS   = "wsus"           // Windows Server Update Services
 )
 
 // Log level constants

--- a/internal/packages/windows.go
+++ b/internal/packages/windows.go
@@ -1,0 +1,136 @@
+package packages
+
+import (
+	"encoding/json"
+	"os/exec"
+	"strings"
+
+	"patchmon-agent/pkg/models"
+
+	"github.com/sirupsen/logrus"
+)
+
+// WindowsManager handles Windows Update package information collection
+type WindowsManager struct {
+	logger *logrus.Logger
+}
+
+// NewWindowsManager creates a new Windows package manager
+func NewWindowsManager(logger *logrus.Logger) *WindowsManager {
+	return &WindowsManager{
+		logger: logger,
+	}
+}
+
+// WindowsUpdate represents a Windows Update item
+type windowsUpdate struct {
+	Title            string `json:"Title"`
+	Description      string `json:"Description"`
+	UpdateID         string `json:"UpdateID"`
+	KBArticleIDs     string `json:"KBArticleIDs"`
+	IsDownloaded     bool   `json:"IsDownloaded"`
+	IsInstalled      bool   `json:"IsInstalled"`
+	IsMandatory      bool   `json:"IsMandatory"`
+	IsSecurityUpdate bool   `json:"IsSecurityUpdate"`
+	Categories       string `json:"Categories"`
+}
+
+// GetPackages gets package information from Windows Update
+func (m *WindowsManager) GetPackages() []models.Package {
+	m.logger.Debug("Collecting Windows Update information...")
+
+	// PowerShell script to get Windows Updates
+	// This uses the Microsoft.Update.Session COM interface
+	psScript := `
+$ErrorActionPreference = "Stop"
+$updateSession = New-Object -ComObject Microsoft.Update.Session
+$updateSearcher = $updateSession.CreateUpdateSearcher()
+$searchResult = $updateSearcher.Search("IsInstalled=0 and IsHidden=0")
+
+$updates = @()
+foreach ($update in $searchResult.Updates) {
+    $kbArticles = ""
+    if ($update.KBArticleIDs.Count -gt 0) {
+        $kbArticles = $update.KBArticleIDs -join ", "
+    }
+    
+    $categories = ""
+    if ($update.Categories.Count -gt 0) {
+        $categoryNames = $update.Categories | ForEach-Object { $_.Name }
+        $categories = $categoryNames -join ", "
+    }
+    
+    $isSecurity = $false
+    if ($categories -like "*Security*" -or $categories -like "*Critical*") {
+        $isSecurity = $true
+    }
+    
+    $updateObj = @{
+        Title = $update.Title
+        Description = $update.Description
+        UpdateID = $update.Identity.UpdateID
+        KBArticleIDs = $kbArticles
+        IsDownloaded = $update.IsDownloaded
+        IsInstalled = $update.IsInstalled
+        IsMandatory = $update.IsMandatory
+        IsSecurityUpdate = $isSecurity
+        Categories = $categories
+    }
+    $updates += $updateObj
+}
+
+$updates | ConvertTo-Json -Compress
+`
+
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", psScript)
+	output, err := cmd.Output()
+	if err != nil {
+		m.logger.WithError(err).Warn("Failed to query Windows Update (may require admin privileges or no updates available)")
+		// Return empty list if we can't query Windows Update
+		return []models.Package{}
+	}
+
+	updatesJSON := strings.TrimSpace(string(output))
+	if updatesJSON == "" || updatesJSON == "[]" {
+		m.logger.Debug("No Windows Updates available")
+		return []models.Package{}
+	}
+
+	// Parse JSON output
+	var updates []windowsUpdate
+	if err := json.Unmarshal([]byte(updatesJSON), &updates); err != nil {
+		m.logger.WithError(err).Warn("Failed to parse Windows Update JSON")
+		return []models.Package{}
+	}
+
+	// Convert to Package models
+	var packages []models.Package
+	for _, update := range updates {
+		// Use UpdateID or Title as package name
+		name := update.UpdateID
+		if name == "" {
+			name = update.Title
+		}
+
+		// Extract version if available (often in KB number)
+		currentVersion := "installed"
+		availableVersion := ""
+		if update.KBArticleIDs != "" {
+			availableVersion = "KB" + update.KBArticleIDs
+		} else {
+			availableVersion = update.UpdateID
+		}
+
+		packages = append(packages, models.Package{
+			Name:             name,
+			CurrentVersion:   currentVersion,
+			AvailableVersion: availableVersion,
+			NeedsUpdate:      true,
+			IsSecurityUpdate: update.IsSecurityUpdate,
+		})
+	}
+
+	m.logger.WithField("count", len(packages)).Info("Found Windows Updates")
+	return packages
+}
+

--- a/internal/repositories/windows.go
+++ b/internal/repositories/windows.go
@@ -1,0 +1,144 @@
+package repositories
+
+import (
+	"encoding/json"
+	"os/exec"
+	"strings"
+
+	"patchmon-agent/internal/constants"
+	"patchmon-agent/pkg/models"
+
+	"github.com/sirupsen/logrus"
+)
+
+// WindowsManager handles Windows Update source information collection
+type WindowsManager struct {
+	logger *logrus.Logger
+}
+
+// NewWindowsManager creates a new Windows repository manager
+func NewWindowsManager(logger *logrus.Logger) *WindowsManager {
+	return &WindowsManager{
+		logger: logger,
+	}
+}
+
+// windowsUpdateSource represents a Windows Update source
+type windowsUpdateSource struct {
+	Name        string `json:"Name"`
+	URL         string `json:"URL"`
+	IsEnabled   bool   `json:"IsEnabled"`
+	IsManaged   bool   `json:"IsManaged"`
+}
+
+// GetRepositories gets Windows Update source information
+func (m *WindowsManager) GetRepositories() ([]models.Repository, error) {
+	m.logger.Debug("Collecting Windows Update sources...")
+
+	// PowerShell script to get Windows Update sources
+	// Check for WSUS or Microsoft Update
+	psScript := `
+$ErrorActionPreference = "Stop"
+$updateSession = New-Object -ComObject Microsoft.Update.Session
+$updateSearcher = $updateSession.CreateUpdateSearcher()
+$serverSelection = $updateSearcher.GetType().InvokeMember("ServerSelection", [System.Reflection.BindingFlags]::GetProperty, $null, $updateSearcher, $null)
+
+$sources = @()
+
+# Check if WSUS is configured
+$useWUServer = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "WUServer" -ErrorAction SilentlyContinue)
+if ($useWUServer) {
+    $wsusServer = $useWUServer.WUServer
+    $sources += @{
+        Name = "Windows Server Update Services (WSUS)"
+        URL = $wsusServer
+        IsEnabled = $true
+        IsManaged = $true
+    }
+}
+
+# Microsoft Update is always available
+$sources += @{
+    Name = "Microsoft Update"
+    URL = "https://update.microsoft.com"
+    IsEnabled = $true
+    IsManaged = $false
+}
+
+$sources | ConvertTo-Json -Compress
+`
+
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", psScript)
+	output, err := cmd.Output()
+	if err != nil {
+		m.logger.WithError(err).Warn("Failed to query Windows Update sources (may require admin privileges)")
+		// Return default Microsoft Update source
+		return []models.Repository{
+			{
+				Name:         "Microsoft Update",
+				URL:          "https://update.microsoft.com",
+				Distribution: "",
+				Components:   "",
+				RepoType:     constants.RepoTypeWU,
+				IsEnabled:    true,
+				IsSecure:     true,
+			},
+		}, nil
+	}
+
+	sourcesJSON := strings.TrimSpace(string(output))
+	if sourcesJSON == "" || sourcesJSON == "[]" {
+		m.logger.Debug("No Windows Update sources found, using default")
+		return []models.Repository{
+			{
+				Name:         "Microsoft Update",
+				URL:          "https://update.microsoft.com",
+				Distribution: "",
+				Components:   "",
+				RepoType:     constants.RepoTypeWU,
+				IsEnabled:    true,
+				IsSecure:     true,
+			},
+		}, nil
+	}
+
+	// Parse JSON output
+	var sources []windowsUpdateSource
+	if err := json.Unmarshal([]byte(sourcesJSON), &sources); err != nil {
+		m.logger.WithError(err).Warn("Failed to parse Windows Update sources JSON")
+		return []models.Repository{
+			{
+				Name:         "Microsoft Update",
+				URL:          "https://update.microsoft.com",
+				Distribution: "",
+				Components:   "",
+				RepoType:     constants.RepoTypeWU,
+				IsEnabled:    true,
+				IsSecure:     true,
+			},
+		}, nil
+	}
+
+	// Convert to Repository models
+	var repositories []models.Repository
+	for _, source := range sources {
+		repoType := constants.RepoTypeWU
+		if strings.Contains(source.Name, "WSUS") {
+			repoType = constants.RepoTypeWSUS
+		}
+
+		repositories = append(repositories, models.Repository{
+			Name:         source.Name,
+			URL:          source.URL,
+			Distribution: "",
+			Components:   "",
+			RepoType:     repoType,
+			IsEnabled:    source.IsEnabled,
+			IsSecure:     true, // Windows Update always uses HTTPS
+		})
+	}
+
+	m.logger.WithField("count", len(repositories)).Debug("Found Windows Update sources")
+	return repositories, nil
+}
+


### PR DESCRIPTION
## Summary

Adds Windows host support to the PatchMon agent, enabling monitoring of Windows servers alongside Linux hosts.

## Changes

- **Windows Update detection**: Query pending updates via PowerShell/COM interface (`Microsoft.Update.Session`)
- **Windows repository detection**: Identify configured update sources
- **Platform-specific service management**: Separate implementations for Windows (`service_windows.go`) and Unix (`service_unix.go`)
- **Cross-platform system info**: OS version, hostname, uptime, reboot detection for Windows
- **Config handling**: Platform-appropriate config file paths
- **Crontab**: Gracefully skip on Windows (not applicable)

## Testing

Tested on:
- Windows Server 2022 (monopoly)
- Windows 11 (jenga)
- Linux test host (patchmon-test)

All three hosts reporting successfully to PatchMon server.

## Related

Addresses PatchMon/PatchMon#11